### PR TITLE
Add concurrency for ci

### DIFF
--- a/.github/workflows/ci-update.yml
+++ b/.github/workflows/ci-update.yml
@@ -13,6 +13,9 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   update-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ env:
   TESTS_WORKFLOW: 'ONLYOFFICE/OneClickInstall-Workspace/.github/workflows/reusable-tests.yml@feature/reusable-workflow'
   DESTROY_RUNNER_WORKFLOW: 'ONLYOFFICE/OneClickInstall-Workspace/.github/workflows/reusable-destroy-runner.yml@feature/reusable-workflow'
 
+concurrency:
+  group: ${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   spin-centos7:           
     name: Make centos7 runner


### PR DESCRIPTION
Now only one ci tests can be runned at the same time. NOTE: Concurrency have a branch group, that mean you cant run more that 1 ci proccess on the branch, but can run parrallel proccesses on different branches