### PR TITLE
Update workspace-install.sh

### DIFF
--- a/workspace-install.sh
+++ b/workspace-install.sh
@@ -105,7 +105,7 @@ if [ "$HELP" == "false" ]; then
 fi
 
 if [ "$DOCKER" == "true" ]; then
-	if [ "${LOCAL_SCRIPTS}" == "true"]; then
+	if [ "${LOCAL_SCRIPTS}" == "true" ]; then
 		bash install.sh ${PARAMETERS}
 	else
 		curl -s -O http://download.onlyoffice.com/install/install.sh


### PR DESCRIPTION
fix install error "workspace-install.sh: line 108: [: missing `]'"