### PR TITLE
Fix documentserver update failure due to unexposed port 8000

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1227,6 +1227,7 @@ install_document_server () {
 	if [ "$RUN_DOCUMENT_SERVER" == "true" ]; then
 		args=();
 		args+=(--name "$DOCUMENT_CONTAINER_NAME");
+		args+=(--expose 8000);
 
 		if [ "${USE_AS_EXTERNAL_SERVER}" == "true" ]; then
 			args+=(-p 80:80);


### PR DESCRIPTION
**Problem**:  
The `wait-for-it.sh` script (used in `run-community-server.sh`) runs indefinitely because the documentserver container does not expose port 8000. This blocks updates triggered from the control panel, as the script waits for a port that is never opened.

**Solution**:  
Expose port 8000 in the documentserver container by modifying its creation command in `install.sh`.

**Details**:  
- The `wait-for-it.sh` script checks for port 8000 to confirm the documentserver is ready.  
- If the port is not exposed, the script hangs indefinitely, preventing updates.  
- Exposing port 8000 ensures the script can detect the container’s readiness and proceed with updates.
