### PR TITLE
Fix the Conflicting distribution warning

### DIFF
--- a/install-Debian/install-preq.sh
+++ b/install-Debian/install-preq.sh
@@ -45,8 +45,8 @@ fi
 # add mono extra repo
 echo "deb [signed-by=/usr/share/keyrings/mono-official-stable.gpg] https://download.mono-project.com/repo/$DIST stable-$DISTRIB_CODENAME/snapshots/6.8.0.123 main" | tee /etc/apt/sources.list.d/mono-official.list
 #Fix missing repository for $DISTRIB_CODENAME
-[[ "$DISTRIB_CODENAME" =~ ^(bullseye|bookworm)$ ]] && sed -i "s/stable-$DISTRIB_CODENAME/stable-buster/g" /etc/apt/sources.list.d/mono-official.list
-[[ "$DISTRIB_CODENAME" =~ ^(jammy|noble)$ ]] && sed -i "s/stable-$DISTRIB_CODENAME/stable-focal/g" /etc/apt/sources.list.d/mono-official.list
+[[ "$DISTRIB_CODENAME" =~ ^(bullseye|bookworm)$ ]] && sed -i "s/stable-$DISTRIB_CODENAME/buster/g" /etc/apt/sources.list.d/mono-official.list
+[[ "$DISTRIB_CODENAME" =~ ^(jammy|noble)$ ]] && sed -i "s/stable-$DISTRIB_CODENAME/focal/g" /etc/apt/sources.list.d/mono-official.list
 
 gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/mono-official-stable.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 chmod 644 /usr/share/keyrings/mono-official-stable.gpg


### PR DESCRIPTION
I got this warning on debian 12 (bookworm):
`W: Conflicting distribution: https://download.mono-project.com/repo/debian stable-buster/snapshots/6.8.0.123 InRelease (expected stable-buster/snapshots/6.8.0.123 but got buster)`

and similar warning on ubuntu 22 (jammy):
`W: Conflicting distribution: https://download.mono-project.com/repo/ubuntu stable-focal/snapshots/6.8.0.123 InRelease (expected stable-focal/snapshots/6.8.0.123 but got focal)`

So I think we can probably remove the prefix `stable-` (Although I haven't tested it on debian 11 and ubuntu 24 yet.)